### PR TITLE
fix: 修复php8.x强转curl句柄为string类型导致的报错

### DIFF
--- a/Aliyun/Log/requestcore.class.php
+++ b/Aliyun/Log/requestcore.class.php
@@ -832,7 +832,11 @@ class RequestCore
 
 		if ($this->response === false)
 		{
-			throw new RequestCore_Exception('cURL resource: ' . (string) $curl_handle . '; cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
+            if (is_resource($curl_handle)) {
+                throw new RequestCore_Exception('cURL resource: ' . (string) $curl_handle . '; cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
+            } else {
+                throw new RequestCore_Exception('cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
+            }
 		}
 
 		$parsed_response = $this->process_response($curl_handle, $this->response);


### PR DESCRIPTION
fix: 修复php8.x强转curl句柄为string类型导致的报错